### PR TITLE
Fix missing colon in cm-editor CSS

### DIFF
--- a/src/lib/cm-editor.ts
+++ b/src/lib/cm-editor.ts
@@ -129,7 +129,7 @@ export class CodeMirrorEditor extends LitElement {
     }
     .cm-editor {
       height: 100%;
-      max-height 100%;
+      max-height: 100%;
     }
     .cm-scroller {
       overflow: auto;


### PR DESCRIPTION
Adds the missing colon to `max-height 100%`. At least I assume that's not intentional.