### PR TITLE
fix(tsx): dialect for jsx language parser

### DIFF
--- a/src/lib/lang-lit.ts
+++ b/src/lib/lang-lit.ts
@@ -96,7 +96,7 @@ export const litTypeScriptLanguage = LRLanguage.define({
 export const litTsxLanguage = LRLanguage.define({
   name: 'lit-tsx',
   parser: jsxLanguage.parser.configure({
-    dialect: 'tsx',
+    dialect: 'jsx ts',
     wrap: litParseWrapper,
   }),
   languageData: jsxLanguage.data.of({}),


### PR DESCRIPTION
I ran into this being a problem while upgrading Codemirror 5 to 6 in playground-elements

See:

https://github.com/codemirror/lang-javascript/blob/main/src/javascript.ts#L73

@justinfagnani 